### PR TITLE
Create ZsStationScience.cfg

### DIFF
--- a/ProbesBeforeCrew/Mod Support/ZsStationScience.cfg
+++ b/ProbesBeforeCrew/Mod Support/ZsStationScience.cfg
@@ -1,0 +1,7 @@
+@EXPERIMENT_DEFINITION:HAS[#id[rocketFuels|advFuels|plasmaFuels]]:NEEDS[!FeatureScience,StationScience,ProbesBeforeCrew]:AFTER[StationScience] {
+    @baseValue = #$scienceCap$
+}
+
+@EXPERIMENT_DEFINITION:HAS[#id[plasmaFuels]]:NEEDS[!FeatureScience,StationScience,ProbesBeforeCrew]:AFTER[StationScience] {
+    @situationMask = 48
+}


### PR DESCRIPTION
Station Science compatch. Eliminates multiple return requirement of the fuels tests and makes plasma science possible at low space altitude for consistency.